### PR TITLE
Fix: Restore `handlePopupSendLotus` definition

### DIFF
--- a/entrypoints/background/modules/wallet.ts
+++ b/entrypoints/background/modules/wallet.ts
@@ -281,6 +281,7 @@ class WalletManager {
       console.error(`failed to cast ${sentiment} vote for ${platform}/${profileId}`, e)
     }
   }
+  handlePopupSendLotus: EventProcessor = async (data: EventData) => {
     const { outAddress, outValue } = data as SendTransactionParams
     try {
       const { txid } = await this.broadcastTx(


### PR DESCRIPTION
Not sure how this managed to get erased before