### PR TITLE
Wallet messaging, performance, stability tweaks

### DIFF
--- a/entrypoints/background/messaging/wallet.ts
+++ b/entrypoints/background/messaging/wallet.ts
@@ -13,7 +13,7 @@ interface WalletMessaging {
   }: {
     outAddress: string
     outValue: number
-  }) => void
+  }) => Promise<string | null>
   'content-script:submitRankVote': ({
     platform,
     profileId,

--- a/entrypoints/background/modules/wallet.ts
+++ b/entrypoints/background/modules/wallet.ts
@@ -290,7 +290,7 @@ class WalletManager {
     this.queue.busy = false
   }
   /** Try to resolve the queued `EventProcessor`s if not already busy doing so */
-  resolveQueuedEventProcessors = () => {
+  private resolveQueuedEventProcessors = () => {
     if (!this.queue.busy) {
       return this.processQueue()
     }
@@ -299,7 +299,7 @@ class WalletManager {
    *
    * @param data
    */
-  handleWsAddedToMempool: EventProcessor = async (data: EventData) => {
+  private handleWsAddedToMempool: EventProcessor = async (data: EventData) => {
     const txid = data as string
     const tx = await this.chronik.tx(txid)
     for (let i = 0; i < tx.outputs.length; i++) {
@@ -381,13 +381,14 @@ class WalletManager {
     invalid.forEach(outpoint => this.wallet.utxos.delete(outpoint.txid))
     this.wallet.balance = (BigInt(this.wallet.balance) - spentBalance).toString()
   }
-  wsWaitForOpen = async () => {
+  private wsWaitForOpen = async () => {
     await this.ws.waitForOpen()
   }
-  wsSubscribeP2PKH = (scriptPayload: string) => this.ws.subscribe('p2pkh', scriptPayload)
-  wsUnsubscribeP2PKH = (scriptPayload: string) =>
+  private wsSubscribeP2PKH = (scriptPayload: string) =>
+    this.ws.subscribe('p2pkh', scriptPayload)
+  private wsUnsubscribeP2PKH = (scriptPayload: string) =>
     this.ws.unsubscribe('p2pkh', scriptPayload)
-  fetchScriptUtxoSet = async () => {
+  private fetchScriptUtxoSet = async () => {
     try {
       const [{ utxos }] = await this.scriptEndpoint.utxos()
       let balance = 0n

--- a/entrypoints/background/modules/wallet.ts
+++ b/entrypoints/background/modules/wallet.ts
@@ -132,7 +132,7 @@ class WalletManager {
   private wallet!: Wallet
   private wsPingInterval!: NodeJS.Timeout
   public queue: EventQueue
-
+  /** */
   constructor() {
     this.queue = {
       busy: false,
@@ -264,6 +264,10 @@ class WalletManager {
     }
     this.resolveQueuedEventProcessors()
   }
+  /**
+   *
+   * @returns
+   */
   private processQueue = async (): Promise<void> => {
     this.queue.busy = true
     try {
@@ -355,6 +359,7 @@ class WalletManager {
       console.error(`failed to send ${outValue} sats to ${outAddress}`, e)
     }
   }
+  /** */
   private reconcileUtxos = async () => {
     const results = await this.chronik.validateUtxos(this.outpoints)
     const invalid: OutPoint[] = []
@@ -400,9 +405,19 @@ class WalletManager {
       // have bigger problems
     }
   }
+  /**
+   * Broadcast signed `txBuf` to Lotus network
+   * @param txBuf Signed transaction buffer
+   * @returns
+   */
   private broadcastTx = async (txBuf: Buffer) => {
     return await this.chronik.broadcastTx(txBuf)
   }
+  /**
+   *
+   * @param param0
+   * @returns
+   */
   private craftRankTx = ({
     platform,
     profileId,


### PR DESCRIPTION
Currently, the `WalletManager` module exposes the queue and processing methods. This needs to be adjusted so that the background service-worker processing is resolved without needing direct access to the `WalletManager` queue and its associated methods. Also convert Chronik-based UTXO reconciliation to manual reconciliation, and add a Chronik WebSocket "ping" interval to keep background service-worker active during idle periods.