### PR TITLE
Fix race condition, ignore unneeded DOM mutations

### DIFF
--- a/entrypoints/twitter.content/index.ts
+++ b/entrypoints/twitter.content/index.ts
@@ -1085,6 +1085,15 @@ export default defineContentScript({
       if (!element.prop('outerHTML')) {
         return
       }
+      // immediately ignore some elements we don't care about
+      else if (
+        element.is('img') ||
+        element.is('a') ||
+        element.is('span') ||
+        element.is(':header')
+      ) {
+        return
+      }
       processMutatedElement(element, mutationType)
     }
     /**

--- a/entrypoints/twitter.content/index.ts
+++ b/entrypoints/twitter.content/index.ts
@@ -195,7 +195,15 @@ export default defineContentScript({
        * @param element
        */
       async processButtonRows(element: JQuery<HTMLElement>) {
-        if (element.has(selector.Article.div.buttonRow).length < 1) {
+        if (
+          // need at least 1 button row element to proceed
+          element.has(selector.Article.div.buttonRow).length < 1 ||
+          // bugfix: some race condition on mobile duplicated vote buttons
+          // this makes sure we don't process button rows we've already mutated
+          element.has(
+            `${selector.Article.button.postUpvoteButton}, ${selector.Article.button.postDownvoteButton}`,
+          ).length
+        ) {
           return
         }
         //console.log('processing button row element', element)


### PR DESCRIPTION
This PR fixes a race condition that was observed on mobile browser where the button rows of some post elements were processed twice, resulting in a malformed button row `div` element (i.e. 3 vote buttons rather than 2). There was also a conditional added to exclude processing for known, unnecessary mutations to save some CPU cycles.