### PR TITLE
Twitter: remove overlay button on unblur

### DIFF
--- a/entrypoints/twitter.content/index.ts
+++ b/entrypoints/twitter.content/index.ts
@@ -1082,7 +1082,7 @@ export default defineContentScript({
         console.log(
           `unblurring post ${profileId}/${postId} (post reputation at or above treshold)`,
         )
-        element.removeClass('blurred').next().remove()
+        element.removeClass('blurred').find('> button').remove()
         //postParentElement.parent()!.style.overflow = 'hidden !important'
       }
     }


### PR DESCRIPTION
This commit finds and removes the overlay button when a post needs to be unblurred, i.e. reputation has become neutral or positive during runtime.

This tweak should have been included in #38.