### PR TITLE
Implement instance registration with RANK API

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = utils/rank-lib
 	url = https://github.com/LotusiaStewardship/rank-lib
 	branch = master
+[submodule "utils/bitcore-lib-xpi"]
+	path = utils/bitcore-lib-xpi
+	url = https://github.com/LotusiaStewardship/bitcore-lib-xpi.git

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+install-links

--- a/components/forms/RegisterInstance.vue
+++ b/components/forms/RegisterInstance.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import { FwbButton } from 'flowbite-vue'
+const emit = defineEmits(['register-instance'])
+</script>
+<template>
+  <div class="flex">
+    <div class="block">
+      <p>
+        Opt-in to the Lotusia Stewardship news bulletin and engagement rewards?
+      </p>
+    </div>
+  </div>
+  <div class="flex">
+    <div class="block">
+      <FwbButton @click="emit('register-instance', true)">Yes</FwbButton>
+    </div>
+    <div class="block">
+      <FwbButton @click="emit('register-instance', false)">No</FwbButton>
+    </div>
+  </div>
+</template>

--- a/entrypoints/background/messaging/index.ts
+++ b/entrypoints/background/messaging/index.ts
@@ -1,1 +1,2 @@
 export { walletMessaging } from './wallet'
+export { instanceMessaging } from './instance'

--- a/entrypoints/background/messaging/instance.ts
+++ b/entrypoints/background/messaging/instance.ts
@@ -1,0 +1,11 @@
+import { defineExtensionMessaging } from '@webext-core/messaging'
+
+interface InstanceMessaging {
+  'popup:registerInstance': (data: {
+    optin: boolean
+    signature: string
+  }) => void
+}
+
+const instanceMessaging = defineExtensionMessaging<InstanceMessaging>()
+export { instanceMessaging }

--- a/entrypoints/background/messaging/wallet.ts
+++ b/entrypoints/background/messaging/wallet.ts
@@ -1,4 +1,4 @@
-import { UIWalletState } from '@/entrypoints/background/stores'
+import type { UIWalletState } from '@/entrypoints/background/stores'
 import { defineExtensionMessaging } from '@webext-core/messaging'
 import type {
   ScriptChunkPlatformUTF8,
@@ -7,6 +7,7 @@ import type {
 
 interface WalletMessaging {
   'background:walletState': (walletState: UIWalletState) => void
+  'popup:loadSigningKey': () => string
   'popup:loadSeedPhrase': () => string
   'popup:seedPhrase': (seedPhrase: string) => Promise<UIWalletState>
   'popup:loadWalletState': () => UIWalletState

--- a/entrypoints/background/modules/wallet.ts
+++ b/entrypoints/background/modules/wallet.ts
@@ -16,6 +16,7 @@ import {
   PrivateKey,
   Transaction,
   Address,
+  Message,
 } from '@abcpros/bitcore-lib-xpi'
 import {
   walletStore,
@@ -78,6 +79,36 @@ type Wallet = {
   script: Script
   utxos: UtxoCache
   balance: string
+}
+/**
+ * Static methods used by popup and potentially elsewhere
+ */
+class WalletTools {
+  /**
+   *
+   * @param text
+   * @param privateKey
+   * @returns
+   */
+  static signMessage(text: string, privateKey: string) {
+    const message = new Message(text)
+    return message.sign(PrivateKey.fromWIF(privateKey))
+  }
+  /**
+   *
+   * @param text
+   * @param address
+   * @param signature
+   * @returns
+   */
+  static verifyMessage(
+    text: string,
+    address: Address | string,
+    signature: string,
+  ) {
+    const message = new Message(text)
+    return message.verify(address, signature)
+  }
 }
 /**
  *
@@ -147,6 +178,10 @@ class WalletManager {
   /** 12-word backup/restore seed phrase */
   get seedPhrase() {
     return this.wallet?.seedPhrase
+  }
+  /** Private key of wallet spending address in WIF format */
+  get signingKey() {
+    return this.wallet?.signingKey.toWIF()
   }
   /** 20-byte public key hash to register Chronik `ScriptEndpoint` */
   get scriptPayload() {
@@ -626,4 +661,4 @@ class WalletManager {
   }
 }
 
-export { WalletManager, WalletBuilder }
+export { WalletManager, WalletBuilder, WalletTools }

--- a/entrypoints/background/stores/index.ts
+++ b/entrypoints/background/stores/index.ts
@@ -2,4 +2,4 @@ export { walletStore } from './wallet'
 export type { WalletState, MutableWalletState, UIWalletState } from './wallet'
 
 export { instanceStore } from './instance'
-export type { InstanceState, PostMeta, PostMetaCache } from './instance'
+export type { ExtensionInstance, PostMeta, PostMetaCache } from './instance'

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -1,22 +1,36 @@
 <script lang="ts" setup>
 import Header from '@/components/Header.vue'
 import Footer from '@/components/Footer.vue'
+import RegisterInstance from '@/components/forms/RegisterInstance.vue'
 import Home from '@/components/pages/Home.vue'
 import Receive from '@/components/pages/Receive.vue'
 import Send from '@/components/pages/Send.vue'
 import Settings from '@/components/pages/Settings.vue'
-import { walletMessaging } from '@/entrypoints/background/messaging'
-import { instanceStore, walletStore } from '@/entrypoints/background/stores'
-import { WalletBuilder } from '@/entrypoints/background/modules/wallet'
+import {
+  instanceMessaging,
+  walletMessaging,
+} from '@/entrypoints/background/messaging'
+import {
+  instanceStore,
+  walletStore,
+  type UIWalletState,
+} from '@/entrypoints/background/stores'
+import {
+  WalletBuilder,
+  WalletTools,
+} from '@/entrypoints/background/modules/wallet'
 import { Unwatch } from 'wxt/storage'
 import type { ShallowRef } from 'vue'
 
 const walletBalance: ShallowRef<string, string> = shallowRef('')
 const walletAddress: ShallowRef<string, string> = shallowRef('')
 //const walletHistory: Ref<object, Record<string, string>> = ref({})
+const registerStatus: ShallowRef<null, boolean> = shallowRef(null)
+const registerPromptAck: ShallowRef<null, boolean> = shallowRef(null)
 const setupComplete: ShallowRef<boolean, boolean> = shallowRef(false)
 const renderComplete: ShallowRef<boolean, boolean> = shallowRef(false)
-const watchers: Map<'balance' | 'address', Unwatch> = new Map()
+const watchers: Map<'balance' | 'address' | 'instance:optin', Unwatch> =
+  new Map()
 
 const beforeUnmount = () => {
   console.log('clean up, clean up')
@@ -28,9 +42,11 @@ const beforeUnmount = () => {
 const beforeMount = () => {
   console.log('before mount')
   // write the platform OS to instanceStore
+  /*
   browser.runtime.getPlatformInfo().then(async platformInfo => {
     await instanceStore.setOs(platformInfo.os)
   })
+  */
   // set up storage watchers
   watchers.set(
     'balance',
@@ -38,6 +54,16 @@ const beforeMount = () => {
       newValue => (walletBalance.value = toXPI(newValue)),
     ),
   )
+  watchers.set(
+    'instance:optin',
+    instanceStore.optinStorageItem.watch(
+      newValue => (registerStatus.value = newValue!),
+    ),
+  )
+  instanceStore.getOptin().then(optin => {
+    registerStatus.value = optin!
+    registerPromptAck.value = optin!
+  })
 }
 
 const sendLotus = async (outAddress: string, outValue: number) => {
@@ -47,6 +73,24 @@ const sendLotus = async (outAddress: string, outValue: number) => {
   })
 }
 
+const instanceRegistration = async (answer: boolean) => {
+  registerPromptAck.value = answer
+  const data = new Map<'signingKey' | 'instanceId', string>()
+  data.set(
+    'signingKey',
+    await walletMessaging.sendMessage('popup:loadSigningKey', undefined),
+  )
+  data.set('instanceId', await instanceStore.getInstanceId())
+  await instanceMessaging.sendMessage('popup:registerInstance', {
+    optin: answer,
+    signature: WalletTools.signMessage(
+      data.get('instanceId')!,
+      data.get('signingKey')!,
+    ),
+  })
+  data.clear()
+}
+
 const walletSetup = async (seedPhrase?: string) => {
   beforeUnmount()
   setupComplete.value = false
@@ -54,14 +98,30 @@ const walletSetup = async (seedPhrase?: string) => {
   // background has no access to window.crypto so popup needs to generate
   const hasSeedPhrase = await walletStore.hasSeedPhrase()
   // request the ui wallet state from the background
-  const walletState =
-    hasSeedPhrase && !seedPhrase
-      ? await walletMessaging.sendMessage('popup:loadWalletState', undefined)
-      : await walletMessaging.sendMessage(
-          'popup:seedPhrase',
-          // use the imported seed phrase if avail, else generate new
-          seedPhrase ?? WalletBuilder.newMnemonic().toString(),
-        )
+  let walletState: UIWalletState
+  // load existing walletState if not trying to import new one
+  if (hasSeedPhrase && !seedPhrase) {
+    walletState = await walletMessaging.sendMessage(
+      'popup:loadWalletState',
+      undefined,
+    )
+  }
+  // use the provided seed phrase to generate walletState
+  else if (seedPhrase) {
+    walletState = await walletMessaging.sendMessage(
+      'popup:seedPhrase',
+      seedPhrase,
+    )
+  }
+  // use new seed phrase to generate walletState
+  else {
+    const seedPhrase = WalletBuilder.newMnemonic().toString()
+    walletState = await walletMessaging.sendMessage(
+      'popup:seedPhrase',
+      seedPhrase,
+    )
+  }
+
   await walletStore.setScriptPayload(walletState.scriptPayload)
   await walletStore.setScripthex(walletState.scriptHex)
   walletAddress.value = walletState.address
@@ -80,8 +140,8 @@ onMounted(walletSetup)
 </script>
 
 <template>
-  <div class="container sm p-4">
-    <template v-if="setupComplete">
+  <template v-if="setupComplete && registerPromptAck !== null">
+    <div class="main container sm p-2">
       <Header :balance="walletBalance" />
       <Receive
         :address="walletAddress"
@@ -89,13 +149,22 @@ onMounted(walletSetup)
         @qr-mounted="renderComplete = true"
       />
       <Footer @import-seed-phrase="walletSetup" />
-    </template>
-    <template v-else> Please wait... </template>
-  </div>
+      extension registered:
+      {{ registerStatus }}
+    </div>
+  </template>
+  <template v-else-if="setupComplete && registerPromptAck === null">
+    <RegisterInstance @register-instance="instanceRegistration" />
+  </template>
+  <template v-else> <div class="p-2">Loading wallet...</div> </template>
 </template>
 
 <style lang="css">
+.main {
+  min-width: 380px;
+}
 div {
+  padding: 4px;
   place-items: center;
 }
 textarea {

--- a/entrypoints/twitter.content/style.css
+++ b/entrypoints/twitter.content/style.css
@@ -113,17 +113,17 @@
   }
   &[data-sentiment~='neutral'] {
     &::after {
-      background: var(--neutral-sentiment) !important;
+      background: var(--neutral-sentiment);
     }
   }
   &[data-sentiment~='positive'] {
     &::after {
-      background: var(--positive-sentiment) !important;
+      background: var(--positive-sentiment);
     }
   }
   &[data-sentiment~='negative'] {
     &::after {
-      background: var(--negative-sentiment) !important;
+      background: var(--negative-sentiment);
     }
   }
 }
@@ -147,17 +147,17 @@
   }
   &[data-sentiment~='neutral'] {
     &::after {
-      background: var(--neutral-sentiment) !important;
+      background: var(--neutral-sentiment);
     }
   }
   &[data-sentiment~='positive'] {
     &::after {
-      background: var(--positive-sentiment) !important;
+      background: var(--positive-sentiment);
     }
   }
   &[data-sentiment~='negative'] {
     &::after {
-      background: var(--negative-sentiment) !important;
+      background: var(--negative-sentiment);
     }
   }
 }
@@ -169,8 +169,8 @@
 .profile-avatar-reputation {
   position: relative;
   &::after {
-    left: 0%;
-    top: 0%;
+    left: 2%;
+    top: 2%;
     height: 20%;
     width: 20%;
     /* background-size: 0.4rem 0.4rem; */
@@ -181,17 +181,17 @@
   }
   &[data-sentiment~='neutral'] {
     &::after {
-      background: var(--neutral-sentiment) !important;
+      background: var(--neutral-sentiment);
     }
   }
   &[data-sentiment~='positive'] {
     &::after {
-      background: var(--positive-sentiment) !important;
+      background: var(--positive-sentiment);
     }
   }
   &[data-sentiment~='negative'] {
     &::after {
-      background: var(--negative-sentiment) !important;
+      background: var(--negative-sentiment);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "vue": "3.5.13"
       },
       "devDependencies": {
-        "@abcpros/bitcore-lib-xpi": "8.25.43",
+        "@abcpros/bitcore-lib-xpi": "file:utils/bitcore-lib-xpi",
         "@abcpros/bitcore-mnemonic": "8.25.43",
         "@types/chrome": "0.0.308",
         "@types/jquery": "3.5.32",
@@ -64,8 +64,7 @@
     },
     "node_modules/@abcpros/bitcore-lib-xpi": {
       "version": "8.25.43",
-      "resolved": "https://registry.npmjs.org/@abcpros/bitcore-lib-xpi/-/bitcore-lib-xpi-8.25.43.tgz",
-      "integrity": "sha512-d9tSQMpFGcX3KGeqdSkQuGGnStjbloVYqZqechDgJyyI5ooY/B47EOhnrl9SHylff/Syp82Ow1UEm2Ng9tMzCA==",
+      "resolved": "file:utils/bitcore-lib-xpi",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1104,6 +1103,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -3447,9 +3459,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3461,14 +3473,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5880,18 +5892,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -8854,9 +8866,9 @@
       }
     },
     "node_modules/pirates": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9745,8 +9757,10 @@
       }
     },
     "node_modules/rank-lib": {
-      "resolved": "utils/rank-lib",
-      "link": true
+      "version": "0.1.0",
+      "resolved": "file:utils/rank-lib",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -10988,6 +11002,36 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -13297,14 +13341,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "utils/rank-lib": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "devDependencies": {
-        "@types/node": "^22.10.7"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vue": "3.5.13"
   },
   "devDependencies": {
-    "@abcpros/bitcore-lib-xpi": "8.25.43",
+    "@abcpros/bitcore-lib-xpi": "file:utils/bitcore-lib-xpi",
     "@abcpros/bitcore-mnemonic": "8.25.43",
     "@types/chrome": "0.0.308",
     "@types/jquery": "3.5.32",


### PR DESCRIPTION
This branch adds all of the requisite modules and runtime logic to register new extension installations with the RANK API backend. This registration is tracked on the backend to determine which installations will receive news bulletins, eligibility for engagement rewards, etc.

The implementation in the popup UI is not pretty, but it is functional and will be further refined in later commits.