### PR TITLE
bugfix: incorrect Lotus value passed to `injectSeedPhrase`

### DIFF
--- a/components/forms/settings/SeedPhrase.vue
+++ b/components/forms/settings/SeedPhrase.vue
@@ -30,7 +30,7 @@ async function handleRestoreSeedPhrase() {
     if (isValidSeedPhrase(restoreSeedPhrase.value)) {
       // ancestor component watches changes to this value
       // only set this value when seed phrase is valid
-      injectSeedPhrase.value = restoreSeedPhrase
+      injectSeedPhrase.value = restoreSeedPhrase.value
     }
   } catch (e) {
     console.warn(e)


### PR DESCRIPTION
This commit fixes a regression introduced in `v1.0.0-beta` that was setting the `ShallowRef` of the seed phrase to the `injectSeedPhrase`, rather than setting the string value of the `ShallowRef`.