### PR TITLE
bugfix: extension popup UI dimensions

### DIFF
--- a/components/layouts/Main.vue
+++ b/components/layouts/Main.vue
@@ -123,7 +123,10 @@ onMounted(() => {
       view.chrome.windows.getCurrent().then(window => {
         console.log(window)
         // extension popup will be offset from browser
-        if (window.top! !== 0 && window.left! !== 0) {
+        if (
+          (window.top! !== 0 && window.left! !== 0) ||
+          window.state != 'normal'
+        ) {
           windowHeight.value = '600px'
           windowWidth.value = '380px'
           //windowType.value = 'popup'


### PR DESCRIPTION
This commit fixes a bug introduced in v1.0.0-beta where the `window.top` and `window.left` properties can both be `0` depending on the monitor on which the browser application is rendered.

This commit adds a check for `window.state` to ensure that the hard-coded popup UI dimensions are set properly.