### PR TITLE
Bugfix: wallet restore seed phrase validation

### DIFF
--- a/components/forms/settings/SeedPhrase.vue
+++ b/components/forms/settings/SeedPhrase.vue
@@ -3,6 +3,10 @@
 import type { ShallowRef } from 'vue'
 import { walletMessaging } from '@/entrypoints/background/messaging'
 import { WalletBuilder } from '@/entrypoints/background/modules/wallet'
+import {
+  WALLET_BIP39_MIN_WORDS,
+  WALLET_BIP39_MAX_WORDS,
+} from '@/utils/constants'
 import { FwbTextarea, FwbButton, FwbP } from 'flowbite-vue'
 /**
  * Constants
@@ -26,15 +30,10 @@ async function toggleExistingSeedPhrase() {
 }
 /** */
 async function handleRestoreSeedPhrase() {
-  try {
-    if (isValidSeedPhrase(restoreSeedPhrase.value)) {
-      // ancestor component watches changes to this value
-      // only set this value when seed phrase is valid
-      injectSeedPhrase.value = restoreSeedPhrase.value
-    }
-  } catch (e) {
-    console.warn(e)
-  } finally {
+  if (isValidSeedPhrase(restoreSeedPhrase.value)) {
+    // ancestor component watches changes to this value
+    // only set this value when seed phrase is valid
+    injectSeedPhrase.value = restoreSeedPhrase.value
     // reset form
     restoreSeedPhrase.value = ''
   }
@@ -45,10 +44,16 @@ async function handleRestoreSeedPhrase() {
  * @param seedPhrase
  */
 function isValidSeedPhrase(seedPhrase: string) {
-  return (
-    WalletBuilder.isValidSeedPhrase(seedPhrase) &&
-    existingSeedPhrase.value !== restoreSeedPhrase.value
-  )
+  try {
+    return (
+      WalletBuilder.isValidSeedPhrase(seedPhrase) &&
+      restoreSeedPhrase.value.split(' ').length >= WALLET_BIP39_MIN_WORDS &&
+      restoreSeedPhrase.value.split(' ').length <= WALLET_BIP39_MAX_WORDS &&
+      existingSeedPhrase.value !== restoreSeedPhrase.value
+    )
+  } catch (e) {
+    console.warn(e)
+  }
 }
 </script>
 <!--

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -5,6 +5,8 @@ export const DEFAULT_RANK_TTL = 10 // number of seconds profile/post ranking is 
 export const WALLET_CHRONIK_URL = 'https://chronik.lotusia.org'
 export const WALLET_BIP44_PURPOSE = 44
 export const WALLET_BIP44_COINTYPE = 10605
+export const WALLET_BIP39_MIN_WORDS = 12
+export const WALLET_BIP39_MAX_WORDS = 24
 export const WALLET_LOTUS_DECIMAL_PRECISION = 6
 // RANK tx constants
 export const RANK_OUTPUT_MIN_VALUE = 100_000_000


### PR DESCRIPTION
Previous behavior would throw an unhandled exception if there were valid words in the seed phrase, but the number of words was not between 12 and 24.

This change adds validation to the restore seed phrase form to handle this case gracefully.