### PR TITLE
Implement `neutral` votes

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -106,7 +106,9 @@ export default defineBackground({
     walletMessaging.onMessage(
       'content-script:submitRankVote',
       async ({ sender, data }) => {
-        const { platform, profileId, sentiment, postId } = data
+        // get the first RANK output to log the vote
+        // first output is the paid RANK output
+        const { platform, profileId, sentiment, postId } = data[0]
         try {
           validateMessageSender(sender.id)
           const txid = (await walletManager.handlePopupSubmitRankVote(

--- a/entrypoints/background/messaging/wallet.ts
+++ b/entrypoints/background/messaging/wallet.ts
@@ -1,9 +1,6 @@
 import type { UIWalletState } from '@/entrypoints/background/stores'
 import { defineExtensionMessaging } from '@webext-core/messaging'
-import type {
-  ScriptChunkPlatformUTF8,
-  ScriptChunkSentimentUTF8,
-} from 'rank-lib'
+import type { RankOutput } from 'rank-lib'
 
 interface WalletMessaging {
   'background:walletState': (walletState: UIWalletState) => void
@@ -19,19 +16,7 @@ interface WalletMessaging {
     outValue: number
   }) => Promise<string>
   'content-script:getScriptPayload': () => Promise<string>
-  'content-script:submitRankVote': ({
-    platform,
-    profileId,
-    sentiment,
-    postId,
-    comment,
-  }: {
-    platform: ScriptChunkPlatformUTF8
-    profileId: string
-    sentiment: ScriptChunkSentimentUTF8
-    postId?: string
-    comment?: string
-  }) => Promise<string>
+  'content-script:submitRankVote': (outputs: RankOutput[]) => Promise<string>
 }
 
 const walletMessaging = defineExtensionMessaging<WalletMessaging>()


### PR DESCRIPTION
This branch adds functionality for multiple RANK outputs in a single transaction. Specifically, two `neutral` votes with 0 output value are added as the 2nd and 3rd OP_RETURN outputs of a paid RANK transaction.