### PR TITLE
Implement authorization TTL

### DIFF
--- a/entrypoints/background/modules/instance.ts
+++ b/entrypoints/background/modules/instance.ts
@@ -1,9 +1,11 @@
 import type { BlockDataSig } from '@/entrypoints/background/stores/instance'
+import type { ChainState } from '@/entrypoints/background/stores/wallet'
 import { AuthorizationData, Util } from '@/utils/rank-lib'
 
 /** blockhash or blockheight */
 const authenticateParam = /blockhash=([a-f0-9]{64})|blockheight=(\d{1,10})/g
 const authorizationHeaderDelimiter = ':::'
+const authorizationTTL = 420 // blocks
 // `WWW-Authenticate:` header types
 export type AuthenticateHeaderPrefix = 'WWW-Authenticate'
 export type AuthenticateScheme = 'BlockDataSig'
@@ -60,6 +62,20 @@ class InstanceTools {
       return null
     }
     return JSON.parse(authDataStr) as AuthorizationData
+  }
+  /**
+   * Check if the authorization TTL is exceeded
+   * @param blockDataSig - The `BlockDataSig` object
+   * @param chainState - The `ChainState` object
+   * @returns `true` if the authorization TTL is exceeded, `false` otherwise
+   */
+  static isAuthorizationExpired(
+    blockDataSig: BlockDataSig,
+    chainState: ChainState,
+  ): boolean {
+    const authorizationBlockHeight = Number(blockDataSig.blockheight)
+    const chainHeight = Number(chainState.tipHeight)
+    return chainHeight - authorizationBlockHeight > authorizationTTL
   }
   /**
    * Parse the authenticate header to extract block data

--- a/entrypoints/background/stores/wallet.ts
+++ b/entrypoints/background/stores/wallet.ts
@@ -143,6 +143,14 @@ class WalletStore {
   get balanceStorageItem() {
     return this.wxtStorageItems.balance
   }
+  /** Popup UI tracks changes to tip height */
+  get tipHeightStorageItem() {
+    return this.wxtStorageItems.tipHeight
+  }
+  /** Popup UI tracks changes to tip hash */
+  get tipHashStorageItem() {
+    return this.wxtStorageItems.tipHash
+  }
   /**
    * Popup UI tracks changes to address, e.g. import new seed phrase
    *


### PR DESCRIPTION
This commit adds the necessary functionality for the extension to track the validity of its existing authorization header for API requests. If the TTL of the header is expired (420 blocks), then the header is renewed.