### PR TITLE
Adjust avatar badge positioning

### DIFF
--- a/entrypoints/twitter.content/style.css
+++ b/entrypoints/twitter.content/style.css
@@ -116,8 +116,8 @@
   .avatar-reputation {
     position: relative;
     &::after {
-      left: -1%;
-      top: -1%;
+      left: -1.5%;
+      top: -1.5%;
       height: 20%;
       width: 20%;
       /* background-size: 0.4rem 0.4rem; */
@@ -465,8 +465,8 @@
   .avatar-reputation {
     position: relative;
     &::after {
-      left: -1%;
-      top: -1%;
+      left: -1.5%;
+      top: -1.5%;
       height: 20%;
       width: 20%;
       /* background-size: 0.4rem 0.4rem; */


### PR DESCRIPTION
This commit adjusts the profile avatar badge positioning, specifically for square avatars. This change ensures that the avatar badge + border covers the entire upper left-hand corner of square avatars.